### PR TITLE
✨ feat: eureka-server 기본 설정 및 환경 구성

### DIFF
--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2024.0.0")
+    set('springCloudVersion', "2025.0.0")
 }
 
 dependencies {

--- a/eureka-server/src/main/java/com/delipick/server/ServerApplication.java
+++ b/eureka-server/src/main/java/com/delipick/server/ServerApplication.java
@@ -2,7 +2,9 @@ package com.delipick.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 
+@EnableEurekaServer
 @SpringBootApplication
 public class ServerApplication {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1

## 📝작업 내용

- Spring Initializr를 통해 eureka-server 프로젝트 생성
- spring-cloud-starter-netflix-eureka-server 의존성 추가
- @EnableEurekaServer 어노테이션 적용하여 Eureka Server 활성화
- application.yml에서 포트 설정 및 Eureka 서버 자체 등록 비활성화(register-with-eureka: false)
- 서버 실행 후 Eureka 정상 동작 확인 완료
- Spring Cloud 2025.0.0으로 업그레이드