### PR TITLE
📦 chore : Spring Cloud 2025.0.0으로 업그레이드

### DIFF
--- a/food-service/build.gradle
+++ b/food-service/build.gradle
@@ -8,7 +8,7 @@ group = 'com.delipick'
 version = '0.0.1-SNAPSHOT'
 
 ext {
-    set('springCloudVersion', "2024.0.0")
+    set('springCloudVersion', "2025.0.0")
 }
 
 java {

--- a/gateway-server/build.gradle
+++ b/gateway-server/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2023.0.3")
+    set('springCloudVersion', "2025.0.0")
 }
 
 dependencies {

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 
 ext {
-    set('springCloudVersion', "2024.0.0")
+    set('springCloudVersion', "2025.0.0")
 }
 
 java {

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -8,7 +8,7 @@ group = 'com.delipick'
 version = '0.0.1-SNAPSHOT'
 
 ext {
-    set('springCloudVersion', "2024.0.0")
+    set('springCloudVersion', "2025.0.0")
 }
 
 java {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3

## 📝작업 내용

- MSA 전반 프로젝트들의 springCloudVersion을 2025.0.0으로 업데이트
- Spring Boot 3.5.x와의 호환성 확보를 위한 의존성 버전 조정
- 빌드 및 실행 테스트 완료
- 기존 호환 문제로 발생하던 APPLICATION FAILED TO START 오류 해결